### PR TITLE
Migrating to Splash-common 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"mouf/utils.constants.secret" : "~1.0",
 		"mouf/utils.constants.debug" : "~1.0",
 		"psr/log" : "~1.0",
-		"franzl/whoops-middleware" : "~0.3",
+		"middlewares/whoops" : "^0.3",
 		"mouf/utils.value.common-value": "~1.0",
 		"mouf/utils.common.doctrine-annotations-wrapper": "~1.2",
 		"mouf/utils.cache.psr6-ui": "~1.0",
@@ -47,12 +47,12 @@
 					"scope" : "global",
 					"description" : "Create RootController and root view.",
 					"type" : "url",
-					"url" : "splash8install/"
+					"url" : "splash82install/"
 				}, {
 					"scope" : "global",
 					"description" : "Write .htaccess file.",
 					"type" : "url",
-					"url" : "splash8install/writeHtAccess"
+					"url" : "splash82install/writeHtAccess"
 				}
 			],
 			"logo" : "logo.png",

--- a/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
+++ b/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
@@ -145,7 +145,17 @@ class SplashInstallController extends Controller
     {
         // The ErrorRouter class has been removed. Let's check if we use it. If yes, we must migrate.
         $allInstances = $moufManager->getInstancesList();
-        return array_search('Mouf\\Mvc\\Splash\\Routers\\ErrorRouter', $allInstances);
+        return array_search('Mouf\\Mvc\\Splash\\Routers\\ErrorRouter', $allInstances, true) !== false;
+    }
+
+    private function removeErrorRouters(MoufManager $moufManager)
+    {
+        $allInstances = $moufManager->getInstancesList();
+        foreach ($allInstances as $instanceName => $className) {
+            if ($className === 'Mouf\\Mvc\\Splash\\Routers\\ErrorRouter') {
+                $moufManager->removeComponent($instanceName);
+            }
+        }
     }
 
     /**
@@ -214,6 +224,7 @@ class SplashInstallController extends Controller
             $moufManager->removeComponent('exceptionRouter');
             $moufManager->removeComponent('httpErrorsController');
             $moufManager->removeComponent('whoopsMiddleware');
+            $this->removeErrorRouters($moufManager);
         }
         if ($moufManager->has('whoopsMiddleware')) {
             // For migration purpose

--- a/src/SplashAdmin.php
+++ b/src/SplashAdmin.php
@@ -14,10 +14,10 @@ $moufManager->bindComponent('splashApacheConfig', 'template', 'moufTemplate');
 $moufManager->bindComponents('splashApacheConfig', 'content', 'block.content');
 $moufManager->bindComponent('splashApacheConfig', 'splashGenerateService', 'splashGenerateService');
 
-$moufManager->declareComponent('splash8install', 'Mouf\\Mvc\\Splash\\Controllers\\Admin\\SplashInstallController', true);
-$moufManager->bindComponent('splash8install', 'template', 'moufInstallTemplate');
-$moufManager->bindComponents('splash8install', 'content', 'block.content');
-$moufManager->bindComponent('splash8install', 'splashGenerateService', 'splashGenerateService');
+$moufManager->declareComponent('splash82install', 'Mouf\\Mvc\\Splash\\Controllers\\Admin\\SplashInstallController', true);
+$moufManager->bindComponent('splash82install', 'template', 'moufInstallTemplate');
+$moufManager->bindComponents('splash82install', 'content', 'block.content');
+$moufManager->bindComponent('splash82install', 'splashGenerateService', 'splashGenerateService');
 
 $moufManager->declareComponent('splashpurgecache', 'Mouf\\Mvc\\Splash\\Controllers\\Admin\\SplashPurgeCacheController', true);
 $moufManager->bindComponent('splashpurgecache', 'template', 'moufTemplate');


### PR DESCRIPTION
which means migrating to http-interop v0.4
Also using middlewares/whoops instead of franzl/whoops-middleware because it is more flexible regarding DI.