### PR TITLE
fix call to SplashCreateControllerService::generate, last commit remo…

### DIFF
--- a/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
+++ b/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
@@ -460,7 +460,7 @@ return new Stash\\Pool($compositeDriver);');$whoopsConditionMiddleware = Install
         if (!$this->moufManager->instanceExists('rootController')) {
             $splashGenerateService = new SplashCreateControllerService();
             $splashGenerateService->generate($this->moufManager, 'RootController', 'rootController',
-                $controllernamespace, false, true, false,
+                $controllernamespace, true, false,
                 array(
                     array(
                         'url' => '/',

--- a/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
+++ b/src/Mouf/Mvc/Splash/Controllers/Admin/SplashInstallController.php
@@ -460,7 +460,7 @@ return new Stash\\Pool($compositeDriver);');$whoopsConditionMiddleware = Install
         if (!$this->moufManager->instanceExists('rootController')) {
             $splashGenerateService = new SplashCreateControllerService();
             $splashGenerateService->generate($this->moufManager, 'RootController', 'rootController',
-                $controllernamespace, true, false,
+                $controllernamespace, false, true,
                 array(
                     array(
                         'url' => '/',


### PR DESCRIPTION
Fix call to `SplashCreateControllerService::generate()` call, [last commit](https://github.com/thecodingmachine/mvc.splash-common/commit/7d457b745f0576be6532f6daca3edead0d9317df) in splah-common removes the `$injectDao` variable, but generate function in `SplashInstallController` was still called with the parameter in this function